### PR TITLE
Issue 20773 role key substitution

### DIFF
--- a/src/com/dotcms/plugin/saml/v3/parameters/DotsamlDefaultPropertiesService.java
+++ b/src/com/dotcms/plugin/saml/v3/parameters/DotsamlDefaultPropertiesService.java
@@ -197,6 +197,9 @@ public class DotsamlDefaultPropertiesService {
 		case DOT_SAML_REMOVE_ROLES_PREFIX:
 			defaultParams.setDotSamlRemoveRolesPrefix(value);
 			break;
+		case DOT_SAML_ROLE_KEY_SUBSTITUTION:X:
+			defaultParams.setDotSamlRoleKeySubstitution(value);
+			break;
 		case DOT_SAML_ROLES_ATTRIBUTE:
 			defaultParams.setDotSamlRolesAttribute(value);
 			break;
@@ -272,6 +275,8 @@ public class DotsamlDefaultPropertiesService {
 			return defaultParams.getDotSamlLogoutServiceEndpointUrl();
 		case DOT_SAML_REMOVE_ROLES_PREFIX:
 			return defaultParams.getDotSamlRemoveRolesPrefix();
+		case DOT_SAML_ROLE_KEY_SUBSTITUTION:
+			return defaultParams.getDotSamlRoleKeySubstitution();
 		case DOT_SAML_ROLES_ATTRIBUTE:
 			return defaultParams.getDotSamlRolesAttribute();
 		case DOT_SAML_SERVICE_PROVIDER_CUSTOM_CREDENTIAL_PROVIDER_CLASSNAME:

--- a/src/com/dotcms/plugin/saml/v3/parameters/DotsamlDefaultPropertiesService.java
+++ b/src/com/dotcms/plugin/saml/v3/parameters/DotsamlDefaultPropertiesService.java
@@ -197,7 +197,7 @@ public class DotsamlDefaultPropertiesService {
 		case DOT_SAML_REMOVE_ROLES_PREFIX:
 			defaultParams.setDotSamlRemoveRolesPrefix(value);
 			break;
-		case DOT_SAML_ROLE_KEY_SUBSTITUTION:X:
+		case DOT_SAML_ROLE_KEY_SUBSTITUTION:
 			defaultParams.setDotSamlRoleKeySubstitution(value);
 			break;
 		case DOT_SAML_ROLES_ATTRIBUTE:

--- a/src/com/dotcms/plugin/saml/v3/parameters/DotsamlProperties.java
+++ b/src/com/dotcms/plugin/saml/v3/parameters/DotsamlProperties.java
@@ -42,6 +42,7 @@ public class DotsamlProperties {
 	private Boolean dotcmsSamlPolicyAllowCreate = false;
 	private String dotcmsSamlProtocolBinding = SAMLConstants.SAML2_REDIRECT_BINDING_URI;
 	private String dotSamlRemoveRolesPrefix = StringUtils.EMPTY;
+	private String dotSamlRoleKeySubstitution = StringUtils.EMPTY;
 	private String dotSamlServiceProviderCustomCredentialProviderClassname = null;
 	private Boolean dotcmsSamlUseEncryptedDescriptor = false;
 	private Boolean dotSamlVerifySignatureCredentials = true;
@@ -304,6 +305,14 @@ public class DotsamlProperties {
 
 	public void setDotSamlRemoveRolesPrefix(String dotSamlRemoveRolesPrefix) {
 		this.dotSamlRemoveRolesPrefix = dotSamlRemoveRolesPrefix;
+	}
+
+	public String getDotSamlRoleKeySubstitution() {
+		return dotSamlRoleKeySubstitution;
+	}
+
+	public void setDotSamlRoleKeySubstitution(String dotSamlRoleKeySubstitution) {
+		this.dotSamlRoleKeySubstitution = dotSamlRoleKeySubstitution;
 	}
 
 	public String getDotSamlServiceProviderCustomCredentialProviderClassname() {

--- a/src/com/dotcms/plugin/saml/v3/parameters/DotsamlPropertyName.java
+++ b/src/com/dotcms/plugin/saml/v3/parameters/DotsamlPropertyName.java
@@ -241,7 +241,14 @@ public enum DotsamlPropertyName {
 	 * prefix by setting this prop.
 	 */
 	DOT_SAML_REMOVE_ROLES_PREFIX("remove.roles.prefix"),
-	
+
+	/**
+	 * Substitution to replace characters from role attribute sent from IdP with another character expression
+	 * For example: role.key.substitution=/_sepsep_/ /
+	 * To replace '_sepsep_' with a space character
+	 */
+	DOT_SAML_ROLE_KEY_SUBSTITUTION("role.key.substitution"),
+
 	/**
 	 * By default dotcms use: "authorisations", but you can override it just
 	 * adding the roles attribute name you want. "authorisations" will be the


### PR DESCRIPTION
Added configuration property : `role.key.substitution`
This property can be set to replace an expression in the role name that comes in the SAML assertion attribute with the given expression when mapping the role name to dotCMS role key.
For example, if the property is set to:
```
role.key.substitution=/_sepsep_/ /
```
Then the role name 'CMS_sepsep_Administrator' from SAML attribute will be replaced with 'CMS Administrator' when the role is mapped to dotCMS role key. 

See also:
https://github.com/dotCMS/core/issues/20773
For additional description of the issue